### PR TITLE
Add support for multiple attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ concise, simple test files with strong flexibility and extensibility.
 - Parallel execution of tests
 - Test against multiple acceptable answers
 - Wildcard matching (`<NUMBER>`, `<WORD>`, `<*>`)
-- Support for testing rich attachments (`<IMAGE>`, `<CARDS>`)
+- Support for testing rich attachments (`<IMAGE>`, `<CARDS>`, `<OTHER>`)
 - Support for regular expressions (`<(st|nt|nd)>`)
 - Show diffs on error
 - Conversation branches
@@ -71,18 +71,38 @@ Dialogue:
           - Bot: <WORD>
 ```
 
+Handling multiple attachments
+
+```YAML
+Title: Conversation with rich messages
+Dialogue:
+  - Bot: Hi
+  - Human: Hello
+  - Human: How are we doing this month?
+  - Bot: "Month-to-date: <IMAGE> <CARDS>"
+  - Human: Show me ad spend compared to last month
+  - Bot: <IMAGE> <IMAGE>
+```
+
 ## Special Tags
 
-You can use the following tags in your test dialogue files:
+You can use the following tags anywhere in the bot’s response:
 
 Tag | Meaning
 --- | ---
 `<*>` | Matches anything, including whitespaces
 `<WORD>` | A single word without whitespaces
-`<IMAGE>` | An image attachment
-`<CARDS>` | A card attachment
 `<(REGEX)>` | Any regex expression, i.e. `<([0-9]{2})>`
 `<$VARNAME>` | An expression from the locale/translation file
+
+You can match one or more attachments **on their own, or at the end** of the
+response:
+
+Tag | Meaning
+--- | ---
+`<CARDS>` | Any card attachment
+`<IMAGE>` | Any image attachment
+`<OTHER>` | Any other type of attachment
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -82,27 +82,30 @@ Dialogue:
   - Bot: "Month-to-date: <IMAGE> <CARDS>"
   - Human: Show me ad spend compared to last month
   - Bot: <IMAGE> <IMAGE>
+  - Human: How is the campaign doing overall?
+  - Bot: According to <IMAGE> and <IMAGE>, it's going great!
 ```
+
+Currently, the order and type of the attachments are checked, as is the text
+that surrounds them, but not the position of the attachments within the text.
+
+> **NOTE**: In versions `0.0.11` and earlier, the text was not checked at all
+> when an attachment was present. If you were sending text along with the
+> attachment, you should add it to your dialogue when upgrading.
 
 ## Special Tags
 
-You can use the following tags anywhere in the bot’s response:
+You can use the following tags in your test dialogue files:
 
 Tag | Meaning
 --- | ---
 `<*>` | Matches anything, including whitespaces
 `<WORD>` | A single word without whitespaces
+`<IMAGE>` | An image attachment
+`<CARDS>` | A card attachment (this includes buttons)
+`<OTHER>` | Any other type of attachment (video, etc.)
 `<(REGEX)>` | Any regex expression, i.e. `<([0-9]{2})>`
 `<$VARNAME>` | An expression from the locale/translation file
-
-You can match one or more attachments **on their own, or at the end** of the
-response:
-
-Tag | Meaning
---- | ---
-`<CARDS>` | Any card attachment
-`<IMAGE>` | Any image attachment
-`<OTHER>` | Any other type of attachment
 
 ## Install
 

--- a/dialogues/examples/multiple-attachments.yml
+++ b/dialogues/examples/multiple-attachments.yml
@@ -1,0 +1,6 @@
+Title: Multiple attachments
+Dialogue:
+  - Human: Hello
+  - Bot: Hi
+  - Human: How is my campaign doing?
+  - Bot: "Here are the stats for this week: <IMAGE> <CARDS>"

--- a/dialogues/examples/simple-attachment.yml
+++ b/dialogues/examples/simple-attachment.yml
@@ -1,0 +1,6 @@
+Title: Simple attachment
+Dialogue:
+  - Human: Hello
+  - Bot: Hi
+  - Human: How is my campaign doing?
+  - Bot: <IMAGE>

--- a/src/clients/botframework_client.ts
+++ b/src/clients/botframework_client.ts
@@ -78,7 +78,7 @@ export class BotFrameworkClient extends Client {
           }
           const message: Message = {
             user,
-            attachments: dlMessage.map((a) => {
+            attachments: dlMessage.attachments.map((a) => {
               if (a.contentType.includes('image')) return Attachment.Image;
               if (a.contentType.includes('hero')) return Attachment.Cards;
               return Attachment.Other;

--- a/src/clients/botframework_client.ts
+++ b/src/clients/botframework_client.ts
@@ -6,7 +6,7 @@ import {
   Activity,
   Message as BotMessage } from 'botframework-directlinejs';
 import { Client } from './client_interface';
-import { Message, MessageType } from '../spec/message';
+import { Message, Attachment } from '../spec/message';
 import * as program from 'commander';
 import * as chalk from 'chalk';
 
@@ -78,16 +78,16 @@ export class BotFrameworkClient extends Client {
           }
           const message: Message = {
             user,
-            messageTypes: [
-              dlMessage.text && MessageType.Text,
+            attachments: [
+              dlMessage.text && Attachment.Text,
               dlMessage.attachments && dlMessage.attachments.some(a =>
-                a.contentType.includes('image')) && MessageType.Image,
+                a.contentType.includes('image')) && Attachment.Image,
               dlMessage.attachments && dlMessage.attachments.some(a =>
-                a.contentType.includes('hero')) && MessageType.Card,
+                a.contentType.includes('hero')) && Attachment.Card,
             ].filter(m => m),
             text: dlMessage.text || null,
           };
-          if (message.messageTypes.length) {
+          if (message.attachments.length) {
             callback(message);
             return;
           }

--- a/src/clients/botframework_client.ts
+++ b/src/clients/botframework_client.ts
@@ -78,16 +78,14 @@ export class BotFrameworkClient extends Client {
           }
           const message: Message = {
             user,
-            attachments: [
-              dlMessage.text && Attachment.Text,
-              dlMessage.attachments && dlMessage.attachments.some(a =>
-                a.contentType.includes('image')) && Attachment.Image,
-              dlMessage.attachments && dlMessage.attachments.some(a =>
-                a.contentType.includes('hero')) && Attachment.Card,
-            ].filter(m => m),
+            attachments: dlMessage.map((a) => {
+              if (a.contentType.includes('image')) return Attachment.Image;
+              if (a.contentType.includes('hero')) return Attachment.Cards;
+              return Attachment.Other;
+            }),
             text: dlMessage.text || null,
           };
-          if (message.attachments.length) {
+          if (message.text || message.attachments.length) {
             callback(message);
             return;
           }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -156,12 +156,12 @@ export class Runner {
       if (response !== null) {
         if (program.verbose) {
           const timing = (new Date().getTime() - this.timing) || 0;
-          if (response.attachments.length === 0) {
+          if (response.text) {
             const texts = response.text.split('\n');
             const truncatedText = texts.length > 5
               ? texts.slice(0, 5).join('\n') + '...' : response.text;
             console.log(chalk.blue('\tBOT', response.user, ':',
-              truncatedText),
+              truncatedText, ...response.attachments.map(a => `<${a}>`)),
               chalk.magenta(` (${timing}ms)`));
           } else {
             console.log(chalk.blue('\tBOT:', response.user, ':', JSON.stringify(response)),

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -156,7 +156,7 @@ export class Runner {
       if (response !== null) {
         if (program.verbose) {
           const timing = (new Date().getTime() - this.timing) || 0;
-          if (response.attachments.includes(Attachment.Text)) {
+          if (response.attachments.length === 0) {
             const texts = response.text.split('\n');
             const truncatedText = texts.length > 5
               ? texts.slice(0, 5).join('\n') + '...' : response.text;
@@ -261,7 +261,7 @@ export class Runner {
         }
         this.client.send({
           user,
-          attachments: [Attachment.Text],
+          attachments: [],
           text: next.query,
         });
       }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,7 +1,7 @@
 'use strict';
 import { Client } from './clients/client_interface';
 import { Dialogue } from './spec/dialogue';
-import { Message, MessageType } from './spec/message';
+import { Message, Attachment } from './spec/message';
 import { Response } from './spec/response';
 import { Turn, TurnType } from './spec/turn';
 import { Config } from './config';
@@ -156,7 +156,7 @@ export class Runner {
       if (response !== null) {
         if (program.verbose) {
           const timing = (new Date().getTime() - this.timing) || 0;
-          if (response.messageTypes.includes(MessageType.Text)) {
+          if (response.attachments.includes(Attachment.Text)) {
             const texts = response.text.split('\n');
             const truncatedText = texts.length > 5
               ? texts.slice(0, 5).join('\n') + '...' : response.text;
@@ -261,7 +261,7 @@ export class Runner {
         }
         this.client.send({
           user,
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: next.query,
         });
       }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -192,12 +192,15 @@ export class Runner {
             expected = `\t\t${matchArray[0]}`;
           }
 
+          let actual = response.text ? [response.text] : [];
+          actual = actual.concat(response.attachments.map(a => `<${a}>`));
+
           this.results.set(test.dialogue, {
             dialogue: test.dialogue,
             passed: false,
             errorMessage: chalk.red(`\t${Runner.getUsername(test)}\n`) +
                           `\tExpected:\n${expected}` +
-                          `\n\tGot:\n\t\t${response.text}`,
+                          `\n\tGot:\n\t\t${actual.join(' ') || null}`,
           });
           this.terminateInstance(test);
           return;

--- a/src/spec/message.ts
+++ b/src/spec/message.ts
@@ -1,7 +1,13 @@
+/*
+ * An enumeration of the possible attachment types.
+ *
+ * `Other` is a catch-all for any attachment type that is not (yet) explicitly
+ * supported.
+ */
 export enum Attachment {
-  Text = 'Text',
   Image = 'Image',
-  Card = 'Card',
+  Cards = 'Cards',
+  Other = 'Other',
 }
 
 export interface Message {

--- a/src/spec/message.ts
+++ b/src/spec/message.ts
@@ -2,12 +2,13 @@
  * An enumeration of the possible attachment types.
  *
  * `Other` is a catch-all for any attachment type that is not (yet) explicitly
- * supported.
+ * supported.  The enum values are used to build the regexes for the attachment
+ * wildcards, e.g. <IMAGE> is derived from 'IMAGE'.
  */
 export enum Attachment {
-  Image = 'Image',
-  Cards = 'Cards',
-  Other = 'Other',
+  Image = 'IMAGE',
+  Cards = 'CARDS',
+  Other = 'OTHER',
 }
 
 export interface Message {

--- a/src/spec/message.ts
+++ b/src/spec/message.ts
@@ -1,11 +1,11 @@
-export enum MessageType {
+export enum Attachment {
   Text = 'Text',
   Image = 'Image',
   Card = 'Card',
 }
 
 export interface Message {
-  messageTypes: MessageType[];
+  attachments: Attachment[];
   text: string;
   user: string;
 }

--- a/src/spec/response.ts
+++ b/src/spec/response.ts
@@ -1,16 +1,14 @@
-import { Message, MessageType  } from './message';
+import { Message, Attachment  } from './message';
 import { Translator } from '../translator';
 import * as program from 'commander';
 
 const wildcardRegex: RegExp = /<\*>/g;
 const wordRegex: RegExp = /<WORD>/g;
 const numberRegex: RegExp = /<NUMBER>/g;
-const imageRegex: RegExp = /<IMAGE>/g;
-const cardsRegex: RegExp = /<CARDS>/g;
 const regexRegex: RegExp = /<\((.+?)\)>/g;
 
 export class Response {
-  responseType: MessageType;
+  attachments: Attachment[];
   private textMatchChecker: RegExp;
   original: string;
 
@@ -18,21 +16,21 @@ export class Response {
     this.original = responseData.trim();
     switch (this.original) {
       case '<IMAGE>':
-        this.responseType = MessageType.Image;
+        this.responseType = Attachment.Image;
         break;
       case '<CARDS>':
-        this.responseType = MessageType.Card;
+        this.responseType = Attachment.Card;
         break;
       default:
-        this.responseType = MessageType.Text;
+        this.responseType = Attachment.Text;
         this.textMatchChecker = new RegExp(Response.transformTags(this.original));
     }
   }
 
   matches(message: Message): boolean {
-    if (!message.messageTypes.includes(this.responseType)) {
+    if (!message.attachments.includes(this.responseType)) {
       return false;
-    } else if (this.responseType === MessageType.Text) {
+    } else if (this.responseType === Attachment.Text) {
       return message.text.trim().match(this.textMatchChecker) !== null;
     } else {
       return true;
@@ -43,8 +41,6 @@ export class Response {
     regexRegex.lastIndex = 0;
 
     const taggedText = text
-      .replace(imageRegex, '')
-      .replace(cardsRegex, '')
       .replace(wildcardRegex, '<([\\s\\S]*?)>')
       .replace(wordRegex, '<([^ ]+?)>')
       .replace(numberRegex, '<([0-9\.,-]+)>');

--- a/src/spec/response.ts
+++ b/src/spec/response.ts
@@ -58,13 +58,16 @@ export class Response {
       return false;
     }
 
-    // Check that we have the same number, kind, and order of attachments.
-    // We can use JSON.stringify here since we know attachments is just a
-    // simple array of strings.
-
     // Check that we have the right number of attachments.
-    if (JSON.stringify(this.attachments) !== JSON.stringify(message.attachments)) {
+    if (this.attachments.length !== message.attachments.length) {
       return false;
+    }
+
+    // Check that we have the right types of attachments.
+    for (let i = 0; i < this.attachments.length; i += 1) {
+      if (this.attachments[i] !== message.attachments[i]) {
+        return false;
+      }
     }
 
     // Everything appears to be in order.

--- a/src/spec/response.ts
+++ b/src/spec/response.ts
@@ -58,16 +58,13 @@ export class Response {
       return false;
     }
 
-    // Check that we have the right number of attachments.
-    if (this.attachments.length !== message.attachments.length) {
-      return false;
-    }
+    // Check that we have the same number, kind, and order of attachments.
+    // We can use JSON.stringify here since we know attachments is just a
+    // simple array of strings.
 
-    // Check that we have the right types of attachments.
-    for (let i = 0; i < this.attachments.length; i += 1) {
-      if (this.attachments[i] !== message.attachments[i]) {
-        return false;
-      }
+    // Check that we have the right number of attachments.
+    if (JSON.stringify(this.attachments) !== JSON.stringify(message.attachments)) {
+      return false;
     }
 
     // Everything appears to be in order.

--- a/src/spec/response.ts
+++ b/src/spec/response.ts
@@ -7,34 +7,71 @@ const wordRegex: RegExp = /<WORD>/g;
 const numberRegex: RegExp = /<NUMBER>/g;
 const regexRegex: RegExp = /<\((.+?)\)>/g;
 
+// Matches an attachment wildcard (e.g. <IMAGE>) at the _end_ of responseData.
+//
+// The matched part is just the word in the brackets ('IMAGE'), which can be
+// directly compared against the Attachment enum (from which it was generated).
+const attachmentAlternatives = Object.values(Attachment).join('|');
+const attachmentsRegex = new RegExp(`\\s*<(${attachmentAlternatives})>$`);
+
 export class Response {
   attachments: Attachment[];
   private textMatchChecker: RegExp;
+  private bodyText: string;
   original: string;
 
   constructor(responseData: string) {
+    this.attachments = [];
     this.original = responseData.trim();
-    switch (this.original) {
-      case '<IMAGE>':
-        this.responseType = Attachment.Image;
-        break;
-      case '<CARDS>':
-        this.responseType = Attachment.Card;
-        break;
-      default:
-        this.responseType = Attachment.Text;
-        this.textMatchChecker = new RegExp(Response.transformTags(this.original));
+    this.bodyText = this.original;
+
+    // Construct a list of attachments from the attachment wildcards at the
+    // end of the response data.  The end result is that `this.bodyText`
+    // contains only the body text and potentially some inline wildcards;
+    // and `this.attachments` contains a list of attachment types, in the
+    // same order as they originally were in the supplied data.
+    let match;
+    while ((match = this.bodyText.match(attachmentsRegex)) != null) {
+      this.attachments.push(match[1]);
+      this.bodyText = this.bodyText.slice(0, match.index);
     }
+    this.attachments.reverse();
+
+    // Construct a regex to match the remaining body text in terms of its
+    // inline wildcards.
+    this.textMatchChecker = new RegExp(Response.transformTags(this.bodyText));
   }
 
   matches(message: Message): boolean {
-    if (!message.attachments.includes(this.responseType)) {
+
+    // If we are expecting a message body, check that we have one...
+    if (this.bodyText && !message.text) {
       return false;
-    } else if (this.responseType === Attachment.Text) {
-      return message.text.trim().match(this.textMatchChecker) !== null;
-    } else {
-      return true;
     }
+
+    // ...and check that the content is the same.
+    //
+    // Note that we ignore the message body altogether if the spec doesn't
+    // include one.  This is for backwards compatibility with when <IMAGE>
+    // and <CARDS> could only be used in place of the entire message.
+    if (this.bodyText && message.text.trim().match(this.textMatchChecker) === null) {
+      return false;
+    }
+
+    // Check that we have the right number of attachments.
+    if (this.attachments.length !== message.attachments.length) {
+      return false;
+    }
+
+    // Check that we have the right types of attachments.
+    for (let i = 0; i < this.attachments.length; i += 1) {
+      if (this.attachments[i] !== message.attachments[i]) {
+        return false;
+      }
+    }
+
+    // Everything appears to be in order.
+    return true;
   }
 
   static transformTags(text: string): string {

--- a/src/test/runner.ts
+++ b/src/test/runner.ts
@@ -3,7 +3,7 @@ import { Runner } from '../runner';
 import { MockClient } from '../clients/mock_client';
 import { defaultConfig } from '../config';
 import { Dialogue } from '../spec/dialogue';
-import { MessageType } from '../spec/message';
+import { Attachment } from '../spec/message';
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -27,19 +27,19 @@ describe('runner.ts', () => {
         });
         expect(client.read(username)).to.equal('Hello');
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'Hi',
           user: username,
         });
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'How are you?',
           user: username,
         });
         expect(client.read(username)).to.equal('I\'m good');
         expect(client.read(username)).to.equal('Yourself?');
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'I\'m good too',
           user: username,
         });
@@ -66,19 +66,19 @@ describe('runner.ts', () => {
         });
         expect(client.read(username)).to.equal('Hello');
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: '123',
           user: username,
         });
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'Hi',
           user: username,
         });
         expect(client.read(username)).to.equal('I\'m good');
         expect(client.read(username)).to.equal('Yourself?');
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'I\'m good too',
           user: username,
         });
@@ -130,7 +130,7 @@ describe('runner.ts', () => {
           terminated: false,
         });
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'Bye',
           user: username,
         });
@@ -174,14 +174,14 @@ describe('runner.ts', () => {
 
         expect(client.read(users[0])).to.equal('Can you assist me?');
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'Ok',
           user: users[0],
         });
         // This ends user0
         
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'Howdy',
           user: users[1],
         });
@@ -189,21 +189,21 @@ describe('runner.ts', () => {
         expect(client.read(users[1])).to.equal('Are you a cowboy?');
 
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'Yes',
           user: users[1],
         });
         expect(client.read(users[1])).to.equal('Really?');
         expect(client.read(users[1])).to.equal('Can you assist me?');
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'No',
           user: users[1],
         });
         // This ends user1
         
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'Howdy',
           user: users[2],
         });
@@ -211,7 +211,7 @@ describe('runner.ts', () => {
         expect(client.read(users[2])).to.equal('Are you a cowboy?');
 
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'No',
           user: users[2],
         });
@@ -251,13 +251,13 @@ describe('runner.ts', () => {
 
         expect(client.read(users[0])).to.equal('Can you assist me?');
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'Random text',
           user: users[0],
         });
         // user0 fails now
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'Howdy',
           user: users[1],
         });
@@ -266,7 +266,7 @@ describe('runner.ts', () => {
         // user1 shortcircuits
         
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'Howdy',
           user: users[2],
         });
@@ -309,26 +309,26 @@ describe('runner.ts', () => {
 
         expect(client.read(username)).to.equal('Hi there');
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'Hey',
           user: username,
         });
 
         expect(client.read(username)).to.equal('Hello');
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'Hi',
           user: username,
         });
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'How are you?',
           user: username,
         });
         expect(client.read(username)).to.equal('I\'m good');
         expect(client.read(username)).to.equal('Yourself?');
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'I\'m good too',
           user: username,
         });
@@ -361,14 +361,14 @@ describe('runner.ts', () => {
 
         expect(client.read(username)).to.equal('Show me some cats');
         client.reply({
-          messageTypes: [MessageType.Image],
+          attachments: [Attachment.Image],
           text: null,
           user: username,
         });
 
         expect(client.read(username)).to.equal('What can you do?');
         client.reply({
-          messageTypes: [MessageType.Card],
+          attachments: [Attachment.Cards],
           text: null,
           user: username,
         });
@@ -401,7 +401,7 @@ describe('runner.ts', () => {
 
         expect(client.read(username)).to.equal('Hey there');
         client.reply({
-          messageTypes: [MessageType.Text],
+          attachments: [Attachment.Text],
           text: 'How are you?',
           user: username,
         });
@@ -412,7 +412,7 @@ describe('runner.ts', () => {
         setTimeout(() => {
           expect(client.read(username)).to.equal('Hola');
           client.reply({
-            messageTypes: [MessageType.Text],
+            attachments: [Attachment.Text],
             text: 'Como estas?',
             user: username,
           });

--- a/src/test/runner.ts
+++ b/src/test/runner.ts
@@ -27,19 +27,19 @@ describe('runner.ts', () => {
         });
         expect(client.read(username)).to.equal('Hello');
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'Hi',
           user: username,
         });
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'How are you?',
           user: username,
         });
         expect(client.read(username)).to.equal('I\'m good');
         expect(client.read(username)).to.equal('Yourself?');
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'I\'m good too',
           user: username,
         });
@@ -66,19 +66,19 @@ describe('runner.ts', () => {
         });
         expect(client.read(username)).to.equal('Hello');
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: '123',
           user: username,
         });
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'Hi',
           user: username,
         });
         expect(client.read(username)).to.equal('I\'m good');
         expect(client.read(username)).to.equal('Yourself?');
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'I\'m good too',
           user: username,
         });
@@ -130,7 +130,7 @@ describe('runner.ts', () => {
           terminated: false,
         });
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'Bye',
           user: username,
         });
@@ -174,14 +174,14 @@ describe('runner.ts', () => {
 
         expect(client.read(users[0])).to.equal('Can you assist me?');
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'Ok',
           user: users[0],
         });
         // This ends user0
         
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'Howdy',
           user: users[1],
         });
@@ -189,21 +189,21 @@ describe('runner.ts', () => {
         expect(client.read(users[1])).to.equal('Are you a cowboy?');
 
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'Yes',
           user: users[1],
         });
         expect(client.read(users[1])).to.equal('Really?');
         expect(client.read(users[1])).to.equal('Can you assist me?');
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'No',
           user: users[1],
         });
         // This ends user1
         
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'Howdy',
           user: users[2],
         });
@@ -211,7 +211,7 @@ describe('runner.ts', () => {
         expect(client.read(users[2])).to.equal('Are you a cowboy?');
 
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'No',
           user: users[2],
         });
@@ -251,13 +251,13 @@ describe('runner.ts', () => {
 
         expect(client.read(users[0])).to.equal('Can you assist me?');
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'Random text',
           user: users[0],
         });
         // user0 fails now
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'Howdy',
           user: users[1],
         });
@@ -266,7 +266,7 @@ describe('runner.ts', () => {
         // user1 shortcircuits
         
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'Howdy',
           user: users[2],
         });
@@ -309,26 +309,26 @@ describe('runner.ts', () => {
 
         expect(client.read(username)).to.equal('Hi there');
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'Hey',
           user: username,
         });
 
         expect(client.read(username)).to.equal('Hello');
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'Hi',
           user: username,
         });
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'How are you?',
           user: username,
         });
         expect(client.read(username)).to.equal('I\'m good');
         expect(client.read(username)).to.equal('Yourself?');
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'I\'m good too',
           user: username,
         });
@@ -401,7 +401,7 @@ describe('runner.ts', () => {
 
         expect(client.read(username)).to.equal('Hey there');
         client.reply({
-          attachments: [Attachment.Text],
+          attachments: [],
           text: 'How are you?',
           user: username,
         });
@@ -412,7 +412,7 @@ describe('runner.ts', () => {
         setTimeout(() => {
           expect(client.read(username)).to.equal('Hola');
           client.reply({
-            attachments: [Attachment.Text],
+            attachments: [],
             text: 'Como estas?',
             user: username,
           });

--- a/src/test/spec/response.ts
+++ b/src/test/spec/response.ts
@@ -19,15 +19,6 @@ describe('response.ts', () => {
     expect(Response.transformTags('Hey <*>')).to.equal('^Hey ([\\s\\S]*?)$');
     expect(Response.transformTags('Hey <WORD> there')).to.equal('^Hey ([^ ]+?) there$');
   });
-  it('should instantiate <CARDS> correctly', () => {
-    expect(new Response(' <CARDS> ').responseType).to.equal(Attachment.Card);
-  });
-  it('should instantiate <IMAGE> correctly', () => {
-    expect(new Response(' <IMAGE> ').responseType).to.equal(Attachment.Image);
-  });
-  it('should match <CARDS> correctly', () => {
-    expect(new Response(' <CARDS> ').responseType).to.equal(Attachment.Card);
-  });
   it('should match <IMAGE> correctly', () => {
     expect(new Response(' <IMAGE> ').matches({
       user: null,
@@ -39,6 +30,24 @@ describe('response.ts', () => {
     expect(new Response(' <CARDS> ').matches({
       user: null,
       text: null,
+      attachments: [Attachment.Cards],
+    })).to.be.true;
+  });
+  it('should ignore text with <IMAGE> if no text is expected', () => {
+    // This is required for backwards compatibility with when <IMAGE>
+    // could only be used as the entire response.
+    expect(new Response(' <IMAGE> ').matches({
+      user: null,
+      text: ' Here is your image: ',
+      attachments: [Attachment.Image],
+    })).to.be.true;
+  });
+  it('should ignore text with <CARDS> if no text is expected', () => {
+    // This is required for backwards compatibility with when <CARD>
+    // could only be used as the entire response.
+    expect(new Response(' <CARDS> ').matches({
+      user: null,
+      text: ' Here are your options: ',
       attachments: [Attachment.Cards],
     })).to.be.true;
   });

--- a/src/test/spec/response.ts
+++ b/src/test/spec/response.ts
@@ -51,6 +51,62 @@ describe('response.ts', () => {
       attachments: [Attachment.Cards],
     })).to.be.true;
   });
+  it('should match correct text with an attachment if text is expected', () => {
+    expect(new Response('Here are your options: <CARDS>').matches({
+      user: null,
+      text: ' Here are your options: ',
+      attachments: [Attachment.Cards],
+    })).to.be.true;
+  });
+  it('should not match incorrect text with an attachment if text is expected', () => {
+    expect(new Response('Here are your options: <CARDS>').matches({
+      user: null,
+      text: 'choose from ',
+      attachments: [Attachment.Cards],
+    })).to.be.false;
+  });
+  it('should not match incorrect type of attachment', () => {
+    expect(new Response('<IMAGE>').matches({
+      user: null,
+      text: null,
+      attachments: [Attachment.Other],
+    })).to.be.false;
+  });
+  it('should not match a missing attachment', () => {
+    expect(new Response('Here you go: <IMAGE> ').matches({
+      user: null,
+      text: 'Here you go:',
+      attachments: [],
+    })).to.be.false;
+  });
+  it('should match multiple attachments', () => {
+    expect(new Response('Here you go:<IMAGE><IMAGE> ').matches({
+      user: null,
+      text: 'Here you go:',
+      attachments: [Attachment.Image, Attachment.Image],
+    })).to.be.true;
+  });
+  it('should not match the wrong number of attachments', () => {
+    expect(new Response('Here you go: <IMAGE> <IMAGE>').matches({
+      user: null,
+      text: 'Here you go:',
+      attachments: [Attachment.Image, Attachment.Image, Attachment.Image],
+    })).to.be.false;
+  });
+  it('should match different types of attachments', () => {
+    expect(new Response(' Here you go:  <IMAGE>  <CARDS> ').matches({
+      user: null,
+      text: 'Here you go:',
+      attachments: [Attachment.Image, Attachment.Cards],
+    })).to.be.true;
+  });
+  it('should not match the wrong order of attachments', () => {
+    expect(new Response(' <IMAGE> <CARDS>').matches({
+      user: null,
+      text: null,
+      attachments: [Attachment.Cards, Attachment.Image],
+    })).to.be.false;
+  });
   it('should match simple phrases correctly', () => {
     expect(new Response('Hello there!').matches(createTextMessage(' Hello there! ')))
       .to.be.true;

--- a/src/test/spec/response.ts
+++ b/src/test/spec/response.ts
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { Response } from '../../spec/response';
-import { Message, MessageType } from '../../spec/message';
+import { Message, Attachment } from '../../spec/message';
 
 export function createTextMessage(text: string): Message {
   return {
     text,
-    messageTypes: [MessageType.Text],
+    attachments: [Attachment.Text],
     user: null,
   };
 }
@@ -20,26 +20,26 @@ describe('response.ts', () => {
     expect(Response.transformTags('Hey <WORD> there')).to.equal('^Hey ([^ ]+?) there$');
   });
   it('should instantiate <CARDS> correctly', () => {
-    expect(new Response(' <CARDS> ').responseType).to.equal(MessageType.Card);
+    expect(new Response(' <CARDS> ').responseType).to.equal(Attachment.Card);
   });
   it('should instantiate <IMAGE> correctly', () => {
-    expect(new Response(' <IMAGE> ').responseType).to.equal(MessageType.Image);
+    expect(new Response(' <IMAGE> ').responseType).to.equal(Attachment.Image);
   });
   it('should match <CARDS> correctly', () => {
-    expect(new Response(' <CARDS> ').responseType).to.equal(MessageType.Card);
+    expect(new Response(' <CARDS> ').responseType).to.equal(Attachment.Card);
   });
   it('should match <IMAGE> correctly', () => {
     expect(new Response(' <IMAGE> ').matches({
       user: null,
       text: null,
-      messageTypes: [MessageType.Image],
+      attachments: [Attachment.Image],
     })).to.be.true;
   });
   it('should match <CARDS> correctly', () => {
     expect(new Response(' <CARDS> ').matches({
       user: null,
       text: null,
-      messageTypes: [MessageType.Card],
+      attachments: [Attachment.Cards],
     })).to.be.true;
   });
   it('should match simple phrases correctly', () => {

--- a/src/test/spec/response.ts
+++ b/src/test/spec/response.ts
@@ -33,23 +33,19 @@ describe('response.ts', () => {
       attachments: [Attachment.Cards],
     })).to.be.true;
   });
-  it('should ignore text with <IMAGE> if no text is expected', () => {
-    // This is required for backwards compatibility with when <IMAGE>
-    // could only be used as the entire response.
+  it('should not match text with <IMAGE> if no text is expected', () => {
     expect(new Response(' <IMAGE> ').matches({
       user: null,
       text: ' Here is your image: ',
       attachments: [Attachment.Image],
-    })).to.be.true;
+    })).to.be.false;
   });
-  it('should ignore text with <CARDS> if no text is expected', () => {
-    // This is required for backwards compatibility with when <CARD>
-    // could only be used as the entire response.
+  it('should not match text with <CARDS> if no text is expected', () => {
     expect(new Response(' <CARDS> ').matches({
       user: null,
       text: ' Here are your options: ',
       attachments: [Attachment.Cards],
-    })).to.be.true;
+    })).to.be.false;
   });
   it('should match correct text with an attachment if text is expected', () => {
     expect(new Response('Here are your options: <CARDS>').matches({
@@ -62,6 +58,13 @@ describe('response.ts', () => {
     expect(new Response('Here are your options: <CARDS>').matches({
       user: null,
       text: 'choose from ',
+      attachments: [Attachment.Cards],
+    })).to.be.false;
+  });
+  it('should not match attachment without text if text is expected', () => {
+    expect(new Response('Here are your options: <CARDS>').matches({
+      user: null,
+      text: null,
       attachments: [Attachment.Cards],
     })).to.be.false;
   });
@@ -105,6 +108,20 @@ describe('response.ts', () => {
       user: null,
       text: null,
       attachments: [Attachment.Cards, Attachment.Image],
+    })).to.be.false;
+  });
+  it('should match multiple attachments within correct text', () => {
+    expect(new Response(' Compare <IMAGE> with <OTHER> ').matches({
+      user: null,
+      text: 'Compare with',
+      attachments: [Attachment.Image, Attachment.Other],
+    })).to.be.true;
+  });
+  it('should not match multiple attachments within incorrect text', () => {
+    expect(new Response(' <IMAGE> vs <OTHER> ').matches({
+      user: null,
+      text: 'Compare with',
+      attachments: [Attachment.Image, Attachment.Other],
     })).to.be.false;
   });
   it('should match simple phrases correctly', () => {

--- a/src/test/spec/response.ts
+++ b/src/test/spec/response.ts
@@ -5,7 +5,7 @@ import { Message, Attachment } from '../../spec/message';
 export function createTextMessage(text: string): Message {
   return {
     text,
-    attachments: [Attachment.Text],
+    attachments: [],
     user: null,
   };
 }


### PR DESCRIPTION
This changeset allows responses to be checked for multiple attachments, sensitive to their number, order, and type. It also allows for the text body sent along with the attachments to be (optionally) checked just like it is for a plain response, and makes it trivial to add support for more attachment types in the future.

The YAML syntax is unchanged (save for the addition of an `<OTHER>` attachment type as a catch-all), and these changes should be fully backwards compatible. To achieve this, I made two compromises, which I think are fairly natural for users: (1) attachments must come at the end of the message spec; and (2) the text body of a response is not checked if the message spec consists _only_ of attachments.